### PR TITLE
switched to globalconfig

### DIFF
--- a/cmd/statsdaemon/main.go
+++ b/cmd/statsdaemon/main.go
@@ -33,40 +33,40 @@ const (
 )
 
 var (
-	listen_addr     = flag.String("listen_addr", ":8125", "listener address for statsd, listens on UDP only.default: :8125")
-	admin_addr      = flag.String("admin_addr", ":8126", "listener address for admin port, default: :8126")
-	profile_addr    = flag.String("profile_addr", "", "listener address for profiler, must be in format :9000")
-	graphite_addr   = flag.String("graphite_addr", "127.0.0.1:2003", "graphite carbon-in url, default: 127.0.0.1:2003")
-	flushInterval   = flag.Int("flush_interval", 10, "flush interval in seconds, default: 10")
-	processes       = flag.Int("processes", 1, "number of processes to use, default: 1")
-	instance        = flag.String("instance", "null", "instance name, defaults to short hostname if not set")
-	prefix_counters = flag.String("prefix_counters", "stats_counts.", "counters prefix, default: stats.counters")
-	prefix_gauges   = flag.String("prefix_gauges", "stats.gauges.", "gauges prefix, default: stats.gauges")
-	prefix_rates    = flag.String("prefix_rates", "stats.", "rates prefix, default: stats. it is recommended that you use stats.rates if possible")
-	prefix_timers   = flag.String("prefix_timers", "stats.timers.", "timers prefix, default: stats.timers")
+	listen_addr     = flag.String("listen_addr", ":8125", "listener address for statsd, listens on UDP only")
+	admin_addr      = flag.String("admin_addr", ":8126", "listener address for admin port")
+	profile_addr    = flag.String("profile_addr", "", "listener address for profiler")
+	graphite_addr   = flag.String("graphite_addr", "127.0.0.1:2003", "graphite carbon-in url")
+	flushInterval   = flag.Int("flush_interval", 10, "flush interval in seconds")
+	processes       = flag.Int("processes", 1, "number of processes to use")
+	instance        = flag.String("instance", "$HOST", "instance name, defaults to short hostname if not set")
+	prefix_counters = flag.String("prefix_counters", "stats_counts.", "counters prefix")
+	prefix_gauges   = flag.String("prefix_gauges", "stats.gauges.", "gauges prefix")
+	prefix_rates    = flag.String("prefix_rates", "stats.", "rates prefix, it is recommended that you use stats.rates if possible")
+	prefix_timers   = flag.String("prefix_timers", "stats.timers.", "timers prefix")
 
-	prefix_m20_counters = flag.String("prefix_m20_counters", "", "counters 2.0 prefix, default: nil")
-	prefix_m20_gauges   = flag.String("prefix_m20_gauges", "", "gauges 2.0 prefix, default: nil")
-	prefix_m20_rates    = flag.String("prefix_m20_rates", "", "rates 2.0 prefix, default: nil")
-	prefix_m20_timers   = flag.String("prefix_m20_timers", "", "timers 2.0 prefix, default: nil")
+	prefix_m20_counters = flag.String("prefix_m20_counters", "", "counters 2.0 prefix")
+	prefix_m20_gauges   = flag.String("prefix_m20_gauges", "", "gauges 2.0 prefix")
+	prefix_m20_rates    = flag.String("prefix_m20_rates", "", "rates 2.0 prefix")
+	prefix_m20_timers   = flag.String("prefix_m20_timers", "", "timers 2.0 prefix")
 
-	legacy_namespace = flag.Bool("legacy_namespace", true, "legacy namespacing (not recommended), default: true")
-	flush_rates      = flag.Bool("flush_rates", true, "send count for counters (using prefix_counters), default: true")
-	flush_counts     = flag.Bool("flush_counts", false, "send count for counters (using prefix_counters), default: false")
+	legacy_namespace = flag.Bool("legacy_namespace", true, "legacy namespacing (not recommended)")
+	flush_rates      = flag.Bool("flush_rates", true, "send count for counters (using prefix_counters)")
+	flush_counts     = flag.Bool("flush_counts", false, "send count for counters (using prefix_counters)")
 
-	percentile_thresholds = flag.String("percentile_thresholds", "", "percential thresholds (used by timers), default: nil")
-	max_timers_per_s      = flag.Uint64("max_timers_per_s", 1000, "max timers per second, default: 1000")
+	percentile_thresholds = flag.String("percentile_thresholds", "", "percential thresholds (used by timers)")
+	max_timers_per_s      = flag.Uint64("max_timers_per_s", 1000, "max timers per second")
 
-	proftrigPath = flag.String("proftrigger_path", "/tmp", "profiler file path, default: /tmp") // "path to store triggered profiles"
+	proftrigPath = flag.String("proftrigger_path", "/tmp", "profiler file path") // "path to store triggered profiles"
 
-	proftrigHeapFreqStr    = flag.String("proftrigger_heap_freq", "60s", "profiler heap frequency, default: 60s")   // "inspect status frequency. set to 0 to disable"
-	proftrigHeapMinDiffStr = flag.String("proftrigger_heap_min_diff", "1h", "profiler heap min difference, default: 1h") // "minimum time between triggered profiles"
-	proftrigHeapThresh     = flag.Int("proftrigger_heap_thresh", 10000000, "profiler heap threshold, default: 10000000")  // "if this many bytes allocated, trigger a profile"
+	proftrigHeapFreqStr    = flag.String("proftrigger_heap_freq", "60s", "profiler heap frequency")   // "inspect status frequency. set to 0 to disable"
+	proftrigHeapMinDiffStr = flag.String("proftrigger_heap_min_diff", "1h", "profiler heap min difference") // "minimum time between triggered profiles"
+	proftrigHeapThresh     = flag.Int("proftrigger_heap_thresh", 10000000, "profiler heap threshold")  // "if this many bytes allocated, trigger a profile"
 
-	proftrigCpuFreqStr    = flag.String("proftrigger_cpu_freq", "60s", "profiler cpu frequency, default: 60s")    // "inspect status frequency. set to 0 to disable"
-	proftrigCpuMinDiffStr = flag.String("proftrigger_cpu_min_diff", "1h", "profiler cpu min difference, default: 1h") // "minimum time between triggered profiles"
-	proftrigCpuDurStr     = flag.String("proftrigger_cpu_dur", "5s", "profiler cpu duration, default 5s")      // "duration of cpu profile"
-	proftrigCpuThresh     = flag.Int("proftrigger_cpu_thresh", 80, "profiler cpu threshold, 80")        // "if this much percent cpu used, trigger a profile"
+	proftrigCpuFreqStr    = flag.String("proftrigger_cpu_freq", "60s", "profiler cpu frequency")    // "inspect status frequency. set to 0 to disable"
+	proftrigCpuMinDiffStr = flag.String("proftrigger_cpu_min_diff", "1h", "profiler cpu min difference") // "minimum time between triggered profiles"
+	proftrigCpuDurStr     = flag.String("proftrigger_cpu_dur", "5s", "profiler cpu duration")      // "duration of cpu profile"
+	proftrigCpuThresh     = flag.Int("proftrigger_cpu_thresh", 80, "profiler cpu threshold")        // "if this much percent cpu used, trigger a profile"
 
 	debug       = flag.Bool("debug", false, "log outgoing metrics, bad lines, and received admin commands")
 	showVersion = flag.Bool("version", false, "print version string")

--- a/cmd/statsdaemon/main.go
+++ b/cmd/statsdaemon/main.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/rakyll/globalconf"
+	"github.com/grafana/globalconf"
 )
 
 const (

--- a/cmd/statsdaemon/main.go
+++ b/cmd/statsdaemon/main.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 
-	"github.com/stvp/go-toml-config"
+	"github.com/rakyll/globalconf"
 )
 
 const (
@@ -33,40 +33,40 @@ const (
 )
 
 var (
-	listen_addr     = config.String("listen_addr", ":8125")
-	admin_addr      = config.String("admin_addr", ":8126")
-	profile_addr    = config.String("profile_addr", "")
-	graphite_addr   = config.String("graphite_addr", "127.0.0.1:2003")
-	flushInterval   = config.Int("flush_interval", 10)
-	processes       = config.Int("processes", 1)
-	instance        = config.String("instance", "null")
-	prefix_counters = config.String("prefix_counters", "stats_counts.")
-	prefix_gauges   = config.String("prefix_gauges", "stats.gauges.")
-	prefix_rates    = config.String("prefix_rates", "stats.")
-	prefix_timers   = config.String("prefix_timers", "stats.timers.")
+	listen_addr     = flag.String("listen_addr", ":8125", "listener address for statsd, listens on UDP only.default: :8125")
+	admin_addr      = flag.String("admin_addr", ":8126", "listener address for admin port, default: :8126")
+	profile_addr    = flag.String("profile_addr", "", "listener address for profiler, must be in format :9000")
+	graphite_addr   = flag.String("graphite_addr", "127.0.0.1:2003", "graphite carbon-in url, default: 127.0.0.1:2003")
+	flushInterval   = flag.Int("flush_interval", 10, "flush interval in seconds, default: 10")
+	processes       = flag.Int("processes", 1, "number of processes to use, default: 1")
+	instance        = flag.String("instance", "null", "instance name, defaults to short hostname if not set")
+	prefix_counters = flag.String("prefix_counters", "stats_counts.", "counters prefix, default: stats.counters")
+	prefix_gauges   = flag.String("prefix_gauges", "stats.gauges.", "gauges prefix, default: stats.gauges")
+	prefix_rates    = flag.String("prefix_rates", "stats.", "rates prefix, default: stats. it is recommended that you use stats.rates if possible")
+	prefix_timers   = flag.String("prefix_timers", "stats.timers.", "timers prefix, default: stats.timers")
 
-	prefix_m20_counters = config.String("prefix_m20_counters", "")
-	prefix_m20_gauges   = config.String("prefix_m20_gauges", "")
-	prefix_m20_rates    = config.String("prefix_m20_rates", "")
-	prefix_m20_timers   = config.String("prefix_m20_timers", "")
+	prefix_m20_counters = flag.String("prefix_m20_counters", "", "counters 2.0 prefix, default: nil")
+	prefix_m20_gauges   = flag.String("prefix_m20_gauges", "", "gauges 2.0 prefix, default: nil")
+	prefix_m20_rates    = flag.String("prefix_m20_rates", "", "rates 2.0 prefix, default: nil")
+	prefix_m20_timers   = flag.String("prefix_m20_timers", "", "timers 2.0 prefix, default: nil")
 
-	legacy_namespace = config.Bool("legacy_namespace", true)
-	flush_rates      = config.Bool("flush_rates", true)
-	flush_counts     = config.Bool("flush_counts", false)
+	legacy_namespace = flag.Bool("legacy_namespace", true, "legacy namespacing (not recommended), default: true")
+	flush_rates      = flag.Bool("flush_rates", true, "send count for counters (using prefix_counters), default: true")
+	flush_counts     = flag.Bool("flush_counts", false, "send count for counters (using prefix_counters), default: false")
 
-	percentile_thresholds = config.String("percentile_thresholds", "")
-	max_timers_per_s      = config.Uint64("max_timers_per_s", 1000)
+	percentile_thresholds = flag.String("percentile_thresholds", "", "percential thresholds (used by timers), default: nil")
+	max_timers_per_s      = flag.Uint64("max_timers_per_s", 1000, "max timers per second, default: 1000")
 
-	proftrigPath = config.String("proftrigger_path", "/tmp") // "path to store triggered profiles"
+	proftrigPath = flag.String("proftrigger_path", "/tmp", "profiler file path, default: /tmp") // "path to store triggered profiles"
 
-	proftrigHeapFreqStr    = config.String("proftrigger_heap_freq", "60s")    // "inspect status frequency. set to 0 to disable"
-	proftrigHeapMinDiffStr = config.String("proftrigger_heap_min_diff", "1h") // "minimum time between triggered profiles"
-	proftrigHeapThresh     = config.Int("proftrigger_heap_thresh", 10000000)  // "if this many bytes allocated, trigger a profile"
+	proftrigHeapFreqStr    = flag.String("proftrigger_heap_freq", "60s", "profiler heap frequency, default: 60s")   // "inspect status frequency. set to 0 to disable"
+	proftrigHeapMinDiffStr = flag.String("proftrigger_heap_min_diff", "1h", "profiler heap min difference, default: 1h") // "minimum time between triggered profiles"
+	proftrigHeapThresh     = flag.Int("proftrigger_heap_thresh", 10000000, "profiler heap threshold, default: 10000000")  // "if this many bytes allocated, trigger a profile"
 
-	proftrigCpuFreqStr    = config.String("proftrigger_cpu_freq", "60s")    // "inspect status frequency. set to 0 to disable"
-	proftrigCpuMinDiffStr = config.String("proftrigger_cpu_min_diff", "1h") // "minimum time between triggered profiles"
-	proftrigCpuDurStr     = config.String("proftrigger_cpu_dur", "5s")      // "duration of cpu profile"
-	proftrigCpuThresh     = config.Int("proftrigger_cpu_thresh", 80)        // "if this much percent cpu used, trigger a profile"
+	proftrigCpuFreqStr    = flag.String("proftrigger_cpu_freq", "60s", "profiler cpu frequency, default: 60s")    // "inspect status frequency. set to 0 to disable"
+	proftrigCpuMinDiffStr = flag.String("proftrigger_cpu_min_diff", "1h", "profiler cpu min difference, default: 1h") // "minimum time between triggered profiles"
+	proftrigCpuDurStr     = flag.String("proftrigger_cpu_dur", "5s", "profiler cpu duration, default 5s")      // "duration of cpu profile"
+	proftrigCpuThresh     = flag.Int("proftrigger_cpu_thresh", 80, "profiler cpu threshold, 80")        // "if this much percent cpu used, trigger a profile"
 
 	debug       = flag.Bool("debug", false, "log outgoing metrics, bad lines, and received admin commands")
 	showVersion = flag.Bool("version", false, "print version string")
@@ -111,11 +111,17 @@ func main() {
 		defer pprof.WriteHeapProfile(f)
 	}
 
-	err := config.Parse(*config_file)
-	if err != nil {
-		fmt.Println(fmt.Sprintf("Could not read config file: %v", err))
-		return
-	}
+	path := ""
+	if _, err := os.Stat(*config_file); err == nil {
+		path = *config_file
+        }
+	conf, err := globalconf.NewWithOptions(&globalconf.Options{
+		Filename:  path,
+		EnvPrefix: "SD_",
+        })
+
+	conf.ParseAll()
+
 
 	proftrigHeapFreq := dur.MustParseUsec("proftrigger_heap_freq", *proftrigHeapFreqStr)
 	proftrigHeapMinDiff := int(dur.MustParseUNsec("proftrigger_heap_min_diff", *proftrigHeapMinDiffStr))

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -51,12 +51,6 @@
 			"revisionTime": "2016-01-24T19:35:03Z"
 		},
 		{
-			"checksumSHA1": "bM0KEShwScin9ADEYWUrkkF27Zk=",
-			"path": "github.com/pelletier/go-toml",
-			"revision": "a1f048ba24490f9b0674a67e1ce995d685cddf4a",
-			"revisionTime": "2017-01-16T02:49:11Z"
-		},
-		{
 			"checksumSHA1": "6B/7widWpxa60dqiH3Eh9qZGQhY=",
 			"path": "github.com/raintank/dur",
 			"revision": "7b06fb4cf9324a785c2dedea9aa4e47769d54b92",
@@ -109,7 +103,13 @@
 			"path": "github.com/tv42/topic",
 			"revision": "aa72cbe81b4823f349da47a4d749cdda61677c09",
 			"revisionTime": "2013-07-29T20:18:30Z"
-		}
+		},
+		{
+			"checksumSHA1": "kwZn/TNKc3VzadRTFiSkVRX+bTs=",
+			"path": "github.com/rakyll/globalconf",
+			"revision": "415abc325023f1a00cd2d9fa512e0e71745791a2",
+			"revisionTime": "2014-08-18T21:38:18Z"
+                }
 	],
 	"rootPath": "github.com/raintank/statsdaemon"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -103,13 +103,7 @@
 			"path": "github.com/tv42/topic",
 			"revision": "aa72cbe81b4823f349da47a4d749cdda61677c09",
 			"revisionTime": "2013-07-29T20:18:30Z"
-		},
-		{
-			"checksumSHA1": "kwZn/TNKc3VzadRTFiSkVRX+bTs=",
-			"path": "github.com/rakyll/globalconf",
-			"revision": "415abc325023f1a00cd2d9fa512e0e71745791a2",
-			"revisionTime": "2014-08-18T21:38:18Z"
-                }
+		}
 	],
 	"rootPath": "github.com/raintank/statsdaemon"
 }


### PR DESCRIPTION
I have switched this to globalconfig however i am pretty new to all of this. I don’t know how to test this further. Any feedback on something else i should do for this merge is appreciated. 

It does seem to take the options and work which is what i'm after. I want to be able to more easily startup statsd in docker containers.

```
SD_ADMIN_ADDR=:9226 ./build/statsdaemon 
Profiling endpoint listening on ""
2017/05/13 15:04:58 statsdaemon instance 'MyServerIsbetterThanYours' starting
2017/05/13 15:04:58 listen tcp: missing port in address ""
Listening on :9226
2017/05/13 15:04:58 listening on :8125

```

